### PR TITLE
fix: subscription and payment flow audit fixes

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -46,9 +46,13 @@ const io = new Server(server, {
 io.on('connection', (socket) => {
   socket.on('join-room', (roomId) => {
     socket.join(roomId);
-    
     socket.emit('room-joined', { roomId, socketId: socket.id });
+  });
 
+  socket.on('leave-room', (roomId) => {
+    if (roomId) {
+      socket.leave(roomId);
+    }
   });
 
   socket.on('disconnect', () => {

--- a/backend/src/routes/pricing.ts
+++ b/backend/src/routes/pricing.ts
@@ -209,18 +209,34 @@ const pricingRoutes = (app: Express, io: Server) => {
 
       // Handle subscription cancellation
       if (eventName === SubscriptionEventTypes.subscription_cancelled) {
-        await cancelSubscriptionHandler({
-          userId,
-        });
-        io.to(userId).emit("subscription-updated", {
-          userId,
-          eventType: eventName
-        });
+        await cancelSubscriptionHandler({ userId });
+        io.to(userId).emit("subscription-updated", { userId, eventType: eventName });
         console.log(`[Webhook] Emitted subscription-cancelled for user: ${userId}`);
       }
 
-      // Handle payment success
+      // Handle subscription expiry and pause — revoke access the same way as cancellation
+      if (
+        eventName === SubscriptionEventTypes.subscription_expired ||
+        eventName === SubscriptionEventTypes.subscription_paused
+      ) {
+        await cancelSubscriptionHandler({ userId });
+        io.to(userId).emit("subscription-updated", { userId, eventType: eventName });
+        console.log(`[Webhook] Emitted ${eventName} for user: ${userId}`);
+      }
+
+      // Handle subscription resume and payment recovery — restore active subscription
+      if (
+        eventName === SubscriptionEventTypes.subscription_resumed ||
+        eventName === SubscriptionEventTypes.subscription_payment_recovered
+      ) {
+        await createUpdateSubscriptionHandler({ userId, subscriptionId, productId, status: 'active' });
+        io.to(userId).emit("subscription-updated", { userId, eventType: eventName, subscriptionId, productId });
+        console.log(`[Webhook] Emitted ${eventName} for user: ${userId}`);
+      }
+
+      // Handle payment success — persist confirmed active subscription then notify frontend
       if (eventName === SubscriptionEventTypes.subscription_payment_success) {
+        await createUpdateSubscriptionHandler({ userId, subscriptionId, productId, status: 'active' });
         io.to(userId).emit("payment-success", {
           userId,
           subscriptionId,

--- a/backend/src/services/subscription.service.ts
+++ b/backend/src/services/subscription.service.ts
@@ -32,6 +32,10 @@ export const createUpdateSubscriptionHandler = async ({
   }
 
   await populatedUser.save();
+
+  if (status !== 'active') {
+    await UserModel.findByIdAndUpdate(userId, { subscription: null });
+  }
 };
 
 export const cancelSubscriptionHandler = async ({
@@ -47,6 +51,10 @@ export const cancelSubscriptionHandler = async ({
   await SubscriptionModel.findByIdAndUpdate(user.subscription._id, {
     status: "cancelled",
     linksAllowed: 0,
+  });
+
+  await UserModel.findByIdAndUpdate(userId, {
+    subscription: null,
   });
 };
 

--- a/backend/src/types/subscription-event-types.enum.ts
+++ b/backend/src/types/subscription-event-types.enum.ts
@@ -2,6 +2,10 @@ export enum SubscriptionEventTypes {
 	subscription_created = 'subscription_created',
 	subscription_updated = 'subscription_updated',
 	subscription_cancelled = 'subscription_cancelled',
+	subscription_expired = 'subscription_expired',
+	subscription_paused = 'subscription_paused',
+	subscription_resumed = 'subscription_resumed',
 	subscription_payment_failed = 'subscription_payment_failed',
-	subscription_payment_success = 'subscription_payment_success'
+	subscription_payment_success = 'subscription_payment_success',
+	subscription_payment_recovered = 'subscription_payment_recovered',
 }

--- a/shortLink/src/app/app.component.ts
+++ b/shortLink/src/app/app.component.ts
@@ -23,14 +23,15 @@ export class AppComponent {
 
     effect(() => {
       const user = this.user();
-      console.log({user});
-      
+
       if (user?._id) {
         this.socketService.joinRoom();
       }
 
       if (user?.subscription) {
         this.pricingService.getProductById(user.subscription.productId);
+      } else {
+        this.pricingService.updateState('subscriptionProduct', null);
       }
     });
   }

--- a/shortLink/src/app/pages/pricing/pricing.component.html
+++ b/shortLink/src/app/pages/pricing/pricing.component.html
@@ -56,7 +56,7 @@
             class="w-full"
             mat-flat-button
             color="primary"
-            [disabled]="product.id === user()?.subscription?.productId"
+            [disabled]="product.id === user()?.subscription?.productId || isCheckoutOpen()"
             (click)="onBuyNow(product.attributes.buy_now_url)"
           >
             {{

--- a/shortLink/src/app/pages/pricing/pricing.component.ts
+++ b/shortLink/src/app/pages/pricing/pricing.component.ts
@@ -4,6 +4,7 @@ import {
   computed,
   CUSTOM_ELEMENTS_SCHEMA,
   inject,
+  signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
@@ -50,6 +51,7 @@ export class PricingComponent {
   userProduct = computed(() => this.user()?.subscription?.productId);
 
   private currentDialogRef: MatDialogRef<ConfirmationComponent> | null = null;
+  isCheckoutOpen = signal(false);
 
   constructor() {
     this.pricingService.getAllProducts().pipe(takeUntilDestroyed()).subscribe();
@@ -114,6 +116,9 @@ export class PricingComponent {
   }
 
   onBuyNow(buyNowUrl: string) {
+    if (this.isCheckoutOpen()) return;
+
+    this.isCheckoutOpen.set(true);
     window.open(
       `${buyNowUrl}?checkout[custom][userId]=${this.user()?._id}`,
       '_blank'
@@ -125,11 +130,12 @@ export class PricingComponent {
   openConfirmationDialog() {
     this.currentDialogRef = this.dialog.open(ConfirmationComponent, {
       width: '400px',
-      disableClose: true, // Prevent closing while processing
+      disableClose: true,
     });
 
     this.currentDialogRef.afterClosed().subscribe(() => {
       this.currentDialogRef = null;
+      this.isCheckoutOpen.set(false);
     });
   }
 

--- a/shortLink/src/app/pages/profile/account-subscription/account-subscription.component.html
+++ b/shortLink/src/app/pages/profile/account-subscription/account-subscription.component.html
@@ -11,15 +11,35 @@
       <span class="plan-price">{{ subscriptionProduct()?.attributes?.price_formatted }}</span>
     </div>
 
-     <!-- Cancel Subscription -->
-  @if (userSubscription()) {
-    <div class="cancel-section !my-3">
-      <button mat-button class="cancel-btn" (click)="onCancelSubscription()">
-        <mat-icon>cancel</mat-icon>
-        Cancel Subscription
-      </button>
-    </div>
-  }
+    <!-- Cancel Subscription -->
+    @if (!showCancelConfirm()) {
+      <div class="cancel-section !my-3">
+        <button
+          mat-button
+          class="cancel-btn"
+          [disabled]="isCancelling()"
+          (click)="onCancelSubscription()"
+        >
+          @if (isCancelling()) {
+            <mat-spinner diameter="16" />
+          } @else {
+            <mat-icon>cancel</mat-icon>
+          }
+          Cancel Subscription
+        </button>
+      </div>
+    }
+
+    <!-- Inline cancel confirmation -->
+    @if (showCancelConfirm()) {
+      <div class="cancel-confirm !my-3">
+        <p class="cancel-confirm-text">Are you sure you want to cancel your subscription? You will lose access immediately.</p>
+        <div class="cancel-confirm-actions">
+          <button mat-flat-button color="warn" (click)="onConfirmCancel()">Yes, cancel</button>
+          <button mat-button (click)="onDismissCancel()">Keep subscription</button>
+        </div>
+      </div>
+    }
   }
 
   <!-- Special Offer Section - Only show if there's a higher tier available -->

--- a/shortLink/src/app/pages/profile/account-subscription/account-subscription.component.scss
+++ b/shortLink/src/app/pages/profile/account-subscription/account-subscription.component.scss
@@ -151,6 +151,26 @@
   }
 }
 
+.cancel-confirm {
+  padding: var(--space-4);
+  border: 1px solid var(--color-error-border);
+  border-radius: var(--radius-md);
+  background: var(--color-error-bg);
+}
+
+.cancel-confirm-text {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-3) 0;
+  line-height: 1.5;
+  font-family: var(--font-family);
+}
+
+.cancel-confirm-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
 ::ng-deep .current-plan-chip .mdc-evolution-chip__text-label {
   color: var(--color-text-primary) !important;
 }

--- a/shortLink/src/app/pages/profile/account-subscription/account-subscription.component.ts
+++ b/shortLink/src/app/pages/profile/account-subscription/account-subscription.component.ts
@@ -4,23 +4,26 @@ import {
   DestroyRef,
   inject,
   input,
+  signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { finalize } from 'rxjs';
 import { PricingService } from 'src/app/services/pricing.service';
 import { User } from 'src/app/shared/types/user.type';
 import { MatChip } from '@angular/material/chips';
 import { MatButton } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { CommonModule } from '@angular/common';
 import { PricingPlan } from 'src/app/shared/enums/pricing.enum';
 import { Router } from '@angular/router';
 
-// Define tier order (lowest to highest)
 const PLAN_ORDER = [PricingPlan.ESSENTIAL, PricingPlan.PRO, PricingPlan.ULTIMATE];
 
 @Component({
   selector: 'app-account-subscription',
-  imports: [MatChip, MatButton, MatIconModule, CommonModule],
+  imports: [MatChip, MatButton, MatIconModule, MatProgressSpinnerModule, MatSnackBarModule, CommonModule],
   templateUrl: './account-subscription.component.html',
   styleUrl: './account-subscription.component.scss',
   standalone: true,
@@ -28,14 +31,17 @@ const PLAN_ORDER = [PricingPlan.ESSENTIAL, PricingPlan.PRO, PricingPlan.ULTIMATE
 export class AccountSubscriptionComponent {
   private pricingService = inject(PricingService);
   private destroyRef = inject(DestroyRef);
-  private router = inject(Router)
+  private router = inject(Router);
+  private snackBar = inject(MatSnackBar);
 
   user = input.required<User | null>();
   userSubscription = computed(() => this.user()?.subscription);
   subscriptionProduct = computed(() => this.pricingService.subscriptionProduct());
   allProducts = computed(() => this.pricingService.products());
 
-  // Get the next tier product (higher than current)
+  showCancelConfirm = signal(false);
+  isCancelling = signal(false);
+
   nextTierProduct = computed(() => {
     const products = this.allProducts();
     const currentProduct = this.subscriptionProduct();
@@ -45,32 +51,26 @@ export class AccountSubscriptionComponent {
     const currentPlanName = currentProduct.attributes?.name;
     const currentTierIndex = PLAN_ORDER.indexOf(currentPlanName as PricingPlan);
 
-    // Find the next tier
     if (currentTierIndex === -1 || currentTierIndex >= PLAN_ORDER.length - 1) {
-      return null; // Already on highest tier or unknown plan
+      return null;
     }
 
     const nextPlanName = PLAN_ORDER[currentTierIndex + 1];
     return products.find((p: any) => p.attributes?.name === nextPlanName) || null;
   });
 
-  // Check if user is on the highest tier
   isHighestTier = computed(() => {
     const currentProduct = this.subscriptionProduct();
     if (!currentProduct) return false;
-
-    const currentPlanName = currentProduct.attributes?.name;
-    return currentPlanName === PricingPlan.ULTIMATE;
+    return currentProduct.attributes?.name === PricingPlan.ULTIMATE;
   });
 
   ngOnInit() {
-    // Load current subscription product
     this.pricingService
       .getProductById(this.userSubscription()?.productId)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe();
 
-    // Load all products to find next tier
     this.pricingService
       .getAllProducts()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -78,9 +78,27 @@ export class AccountSubscriptionComponent {
   }
 
   onCancelSubscription() {
+    this.showCancelConfirm.set(true);
+  }
+
+  onConfirmCancel() {
+    this.isCancelling.set(true);
+    this.showCancelConfirm.set(false);
+
     this.pricingService.cancelSubscription()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe();
+      .pipe(
+        finalize(() => this.isCancelling.set(false)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((result) => {
+        if (result !== null) {
+          this.snackBar.open('Your subscription has been cancelled.', 'Close', { duration: 5000 });
+        }
+      });
+  }
+
+  onDismissCancel() {
+    this.showCancelConfirm.set(false);
   }
 
   onUpgrade() {
@@ -94,6 +112,6 @@ export class AccountSubscriptionComponent {
   }
 
   onChangePlan() {
-    this.router.navigate(['pricing'])
+    this.router.navigate(['pricing']);
   }
 }

--- a/shortLink/src/app/services/pricing.service.ts
+++ b/shortLink/src/app/services/pricing.service.ts
@@ -52,7 +52,7 @@ export class PricingService {
     return this.http
       .delete(
         `${environment.apiUrl}/api/subscriptions/${
-          this.user()?.subscription.subscriptionId
+          this.user()?.subscription?.subscriptionId
         }`, {
           body: {
             userId: this.user()?._id,
@@ -60,13 +60,7 @@ export class PricingService {
         }
       )
       .pipe(
-        switchMap(() => {
-          return this.http
-            .post(`${environment.apiUrl}/api/remove-subscription`, {
-              userId: this.user()?._id,
-            })
-            .pipe(switchMap((res: any) => this.authService.refreshUser()));
-        }),
+        switchMap(() => this.authService.refreshUser()),
         catchError((error) => {
           this.toastService.presentToast({
             position: 'bottom',

--- a/shortLink/src/app/services/socket.service.ts
+++ b/shortLink/src/app/services/socket.service.ts
@@ -1,4 +1,4 @@
-import { computed, inject, Injectable, signal } from '@angular/core';
+import { computed, effect, inject, Injectable, signal, untracked } from '@angular/core';
 import { io, Socket } from 'socket.io-client';
 import { environment } from 'src/environments/environment';
 import { AuthService } from './auth.service';
@@ -103,11 +103,20 @@ export class SocketService {
       console.log('🔗 Links updated via cron:', data);
       this.linksUpdatedSubject.next(data);
     });
+
+    // When user logs out (userId becomes null), disconnect the socket.
+    // Socket.IO automatically removes the socket from all rooms on disconnect.
+    effect(() => {
+      const userId = this.userId();
+      if (!userId && untracked(() => this.hasJoinedRoom())) {
+        this.socket.disconnect();
+      }
+    });
   }
 
   joinRoom() {
     const userId = this.userId();
-    
+
     if (!userId) {
       console.warn('⚠️ Cannot join room: userId is not available');
       return;
@@ -118,7 +127,11 @@ export class SocketService {
     }
 
     if (!this.isConnected()) {
-      console.warn('⚠️ Cannot join room: socket not connected, will join on connect');
+      // Reconnect if socket was explicitly disconnected (e.g. after logout)
+      if (!this.socket.connected) {
+        this.socket.connect();
+      }
+      // Will join the room once the 'connect' event fires
       return;
     }
 


### PR DESCRIPTION
Backend:
- Add missing Lemon Squeezy webhook handlers: subscription_expired, subscription_paused (revoke access), subscription_resumed, subscription_payment_recovered (restore access)
- subscription_payment_success now writes active status to DB before emitting socket event, preventing stale data on refreshUser()
- createUpdateSubscriptionHandler nulls user.subscription when status is not active, so past_due/expired states correctly deactivate the UI
- Add leave-room socket handler so clients can explicitly exit a room

Frontend:
- Socket disconnects on logout via effect() watching userId signal; joinRoom() reconnects the socket if it was previously disconnected
- AppComponent effect clears subscriptionProduct when user.subscription is null, preventing stale plan data after logout or cancellation
- cancelSubscription() fixes optional chaining crash when subscription is null; removes redundant POST /api/remove-subscription call
- Buy Now button is disabled while checkout window is open, preventing double-submit / multiple checkout sessions
- Cancel Subscription now shows an inline confirmation prompt before proceeding; button is disabled with a loading spinner while the API call is in-flight; success shows a snackbar on the profile page